### PR TITLE
ci: fix GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,12 @@ jobs:
         uv run pytest tests/ -v --cov=. --cov-report=xml --cov-report=html --cov-fail-under=50
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         files: ./buildroot-server/coverage.xml
         flags: server
         name: server-coverage
+        fail_ci_if_error: false
 
   # Agent 端 C 代码检查
   test-agent:
@@ -65,7 +66,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Cache apt packages
-      uses: awalsh128/cache-apt-pkgs-action@latest
+      uses: awalsh128/cache-apt-pkgs-action@v1.4.3
       with:
         packages: cmake gcc libssl-dev libjson-c-dev
         version: ubuntu-22.04


### PR DESCRIPTION
## 修复内容

1. **codecov-action@v4 → v3** - v4 需要 token，v3 不需要
2. **添加 fail_ci_if_error: false** - 避免覆盖率上传失败中断 CI
3. **cache-apt-pkgs-action@latest → v1.4.3** - 固定版本避免不稳定

已通过 opencode review 验证。